### PR TITLE
Add support for starting up a marathon app by just referencing a JSON file

### DIFF
--- a/bin/marathon
+++ b/bin/marathon
@@ -3,7 +3,7 @@
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib', 'marathon'))
 require 'trollop'
 
-SUB_COMMANDS = %w[endpoints kill kill_tasks start scale list list_tasks search]
+SUB_COMMANDS = %w[endpoints kill kill_tasks start scale list list_tasks search deploy]
 
 global_opts = Trollop.options do
   version Marathon::VERSION
@@ -18,6 +18,7 @@ Available commands:
   list_tasks  Show a list of an app's running tasks.
   scale       Scale the number of app instances.
   search      Search the current list of apps.
+  deploy      Deploy an app.
   start       Start a new app.
 
 Global options:
@@ -151,6 +152,11 @@ when 'list_tasks'
   puts marathon.list_tasks(cmd_opts[:id]).parsed_response
 when 'search'
   handle_listing(marathon.search(cmd_opts[:id], cmd_opts[:command]))
+when 'deploy'
+  json_file = ARGV.shift
+  puts "Deploying app '#{json_file}'"
+  res = marathon.deploy(json_file)
+  puts res
 else
   Trollop.die "unknown subcommand #{cmd.inspect}"
 end

--- a/lib/marathon/client.rb
+++ b/lib/marathon/client.rb
@@ -1,4 +1,5 @@
 require 'uri'
+require 'multi_json'
 
 module Marathon
   class Client
@@ -62,6 +63,26 @@ module Marathon
     def start(id, opts)
       body = opts.dup
       body[:id] = id
+      wrap_request(:post, '/v2/apps/', :body => body)
+    end
+
+    def deploy(json_file)
+      begin
+        file = File.read(json_file)
+      rescue Exception => e
+        puts e.message
+        exit 1
+      else
+        begin
+          body = MultiJson.load(file)
+        rescue MultiJson::ParseError => exception
+          exception.data # => "{invalid json}"
+          exception.cause # => JSON::ParserError: 795: unexpected token at '{invalid json}'
+          puts exception.message
+          exit 1
+        end
+      end
+
       wrap_request(:post, '/v2/apps/', :body => body)
     end
 


### PR DESCRIPTION
Added a deploy method that just takes a path to a JSON file and calls the API to start up the app. This is a bit more flexible as it allows you to deploy any app via the command line whereas start does not support everything (such as docker containers)

I had considered replacing the start method entirely, but didn't want to break backwards compatibility for people already using the gem... 